### PR TITLE
fix: 修复模型获取失败时的错误信息显示并移除调试日志

### DIFF
--- a/test/ui_example/src/localService.ts
+++ b/test/ui_example/src/localService.ts
@@ -88,7 +88,6 @@ export class LocalModelService implements ModelService {
       const response = await this.request<ModelListResponse>(url, {
         method: 'GET',
       });
-      console.log('listModel response:', response);
       return { models: response.models, error: response.error };
   }
 
@@ -101,11 +100,9 @@ export class LocalModelService implements ModelService {
       if (data.api_header) queryParams.append('api_header', data.api_header);
       if (data.model_type) queryParams.append('model_type', data.model_type);
       const url = `/checkmodel${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
-      console.log('checkModel url:', url);
       const response = await this.request<CheckModelResponse>(url, {
         method: 'GET',
       });
-      console.log('checkModel response:', response);
       return { model: response.model, error: response.error };
   }
 

--- a/ui/ModelModal/package.json
+++ b/ui/ModelModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokowu/modelkit-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A reusable AI model configuration modal component for React applications",
   "private": false,
   "type": "module",

--- a/ui/ModelModal/src/ModelModal.tsx
+++ b/ui/ModelModal/src/ModelModal.tsx
@@ -140,7 +140,10 @@ export const ModelModal: React.FC<ModelModalProps> = ({
           // 解析base_url，将host替换为host.docker.internal
           const url = new URL(value.base_url);
           url.hostname = 'host.docker.internal';
-          value.base_url = url.toString();
+          const newBaseUrl = url.toString();
+          // 永久更新表单中的base_url字段
+          setValue('base_url', newBaseUrl);
+          value.base_url = newBaseUrl;
           modelService.listModel({
             model_type,
             api_key: value.api_key,
@@ -175,7 +178,7 @@ export const ModelModal: React.FC<ModelModalProps> = ({
               setModelLoading(false);
             });
         } else if (res.error) {
-          messageHandler.error("获取模型失败");
+          messageHandler.error("获取模型失败 " + res.error);
           setModelLoading(false);
         } else {
           setModelUserList(

--- a/usecase/modelkit.go
+++ b/usecase/modelkit.go
@@ -356,7 +356,6 @@ func ollamaListModel(baseURL string, httpClient *http.Client, apiHeader string) 
 
 // 通过修复baseURL尝试修复其它供应商check err, 返回用于提示用户如何修复错误
 func tryFixBaseURL(ctx context.Context, req *domain.CheckModelReq, provider consts.ModelProvider, modelType consts.ModelType) (string, error) {
-	log.Println("尝试修复")
 	// 尝试添加v1
 	fixedBaseURL, err := baseURLAddV1(req.BaseURL)
 	// baseurl解析错误，直接返回
@@ -369,13 +368,10 @@ func tryFixBaseURL(ctx context.Context, req *domain.CheckModelReq, provider cons
 		_, err := getChatModelGenerateChat(ctx, provider, modelType, fixedBaseURL, req)
 		// 添加v1有效， 提示用户
 		if err == nil {
-			log.Println("添加v1有效")
 			return "请在API地址末尾添加/v1", nil
 		}
-		log.Println("添加v1无效", err, fixedBaseURL)
 	}
 
-	log.Println("尝试替换host")
 	// url末尾添加v1无效，尝试替换host为host.docker.internal
 	fixedBaseURL, err = baseURLReplaceHost(req.BaseURL)
 	// baseurl解析错误，直接返回
@@ -389,11 +385,9 @@ func tryFixBaseURL(ctx context.Context, req *domain.CheckModelReq, provider cons
 		if err == nil {
 			return "请将host替换为host.docker.internal", nil
 		}
-		log.Println("替换host无效", err, fixedBaseURL)
 	}
 
 	// 替换host也无效，尝试添加v1与替换host
-	log.Println("尝试添加v1与替换host")
 	fixedBaseURL, err = baseURLAddV1(req.BaseURL)
 	// baseurl解析错误，直接返回
 	if err != nil {
@@ -411,7 +405,6 @@ func tryFixBaseURL(ctx context.Context, req *domain.CheckModelReq, provider cons
 		if err == nil {
 			return "API地址末尾添加/v1， host替换为host.docker.internal", nil
 		}
-		log.Println("添加v1与替换host无效", err, fixedBaseURL)
 	}
 	return "", nil
 }


### PR DESCRIPTION
永久更新表单中的base_url字段，避免重复修改
在模型获取失败时显示具体错误信息
移除调试用的console.log和log.Println语句