### PR TITLE
fix: 更新Ollama默认URL并增强URL验证逻辑

### DIFF
--- a/ui/ModelModal/package.json
+++ b/ui/ModelModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokowu/modelkit-ui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A reusable AI model configuration modal component for React applications",
   "private": false,
   "type": "module",

--- a/ui/ModelModal/src/ModelModal.tsx
+++ b/ui/ModelModal/src/ModelModal.tsx
@@ -25,6 +25,7 @@ import { DEFAULT_MODEL_PROVIDERS } from './constants/providers';
 import { getLocaleMessage } from './constants/locale';
 import './assets/fonts/iconfont';
 import { lightTheme } from './theme';
+import { isValidURL } from './utils';
 
 const titleMap: Record<string, string> = {
   ["llm"]: '对话模型',
@@ -508,10 +509,9 @@ export const ModelModal: React.FC<ModelModalProps> = ({
                   message: 'URL 不能为空',
                 },
                 validate: (value) => {
-                  if (!value) return true; // 空值由required规则处理
-                  const hasScheme = /^https?:\/\//i.test(value);
-                  return hasScheme || 'API地址必须包含协议（http://或https://）';
-                },
+                  const res = isValidURL(value);
+                  return res === "" || res;
+                }
               }}
               render={({ field }) => (
                 <TextField
@@ -532,11 +532,6 @@ export const ModelModal: React.FC<ModelModalProps> = ({
                 />
               )}
             />
-            {providerBrand === 'Other' && (
-              <Box sx={{ fontSize: 12, color: 'error.main', mt: 1 }}>
-                模型供应商必须支持与 OpenAI 兼容的 API 格式
-              </Box>
-            )}
             <Stack
               direction={'row'}
               alignItems={'center'}
@@ -687,22 +682,22 @@ export const ModelModal: React.FC<ModelModalProps> = ({
                 </Box>
               </>
             ) : modelUserList.length === 0 ? (
-                <Button
-                  fullWidth
-                  variant='outlined'
-                  loading={modelLoading}
-                  sx={{
-                    mt: 4,
-                    borderRadius: '10px',
-                    boxShadow: 'none',
-                    fontFamily: `var(--font-gilory), var(--font-HarmonyOS), 'PingFang SC', 'Roboto', 'Helvetica', 'Arial', sans-serif`,
-                    color: 'black',
-                    borderColor: 'black'
-                  }}
-                  onClick={handleSubmit(getModel)}
-                >
-                  获取模型列表
-                </Button>
+              <Button
+                fullWidth
+                variant='outlined'
+                loading={modelLoading}
+                sx={{
+                  mt: 4,
+                  borderRadius: '10px',
+                  boxShadow: 'none',
+                  fontFamily: `var(--font-gilory), var(--font-HarmonyOS), 'PingFang SC', 'Roboto', 'Helvetica', 'Arial', sans-serif`,
+                  color: 'black',
+                  borderColor: 'black'
+                }}
+                onClick={handleSubmit(getModel)}
+              >
+                获取模型列表
+              </Button>
             ) : (
               <>
                 <Box sx={{ fontSize: 14, lineHeight: '32px', mt: 2 }}>

--- a/ui/ModelModal/src/constants/providers.ts
+++ b/ui/ModelModal/src/constants/providers.ts
@@ -112,7 +112,7 @@ export const DEFAULT_MODEL_PROVIDERS: ModelProviderMap = {
     embedding: false,
     rerank: false,
     modelDocumentUrl: 'https://github.com/ollama/ollama/tree/main/docs',
-    defaultBaseUrl: 'http://127.0.0.1:11434',
+    defaultBaseUrl: 'http://172.17.0.1:11434',
   },
   SiliconFlow: {
     label: 'SiliconFlow',

--- a/ui/ModelModal/src/utils/index.ts
+++ b/ui/ModelModal/src/utils/index.ts
@@ -15,12 +15,29 @@ export const addOpacityToColor = (color: string, opacity: number): string => {
 /**
  * 验证URL格式
  */
-export const isValidURL = (url: string): boolean => {
+export const isValidURL = (url: string): string => {
   try {
-    new URL(url);
-    return true;
+    const urlObj = new URL(url);
+
+    // 1. 检查是否有 schema
+    if (!urlObj.protocol) {
+      return "URL 必须包含协议（如 http:// 或 https://）";
+    }
+
+    // 2. 检查是否是 localhost 或 127.0.0.1
+    if (urlObj.hostname === 'localhost' || urlObj.hostname === '127.0.0.1') {
+      return "请使用宿主机主机名(linux:172.17.0.1, mac/windows:host.docker.internal)";
+    }
+
+    // 3. 检查是否以 /v+数字 结尾 或者 包含/v+数字/
+    const pathPattern = /\/v\d+(\/.*)?$/;
+    if (!pathPattern.test(urlObj.pathname)) {
+      return "模型供应商必须支持与 OpenAI 兼容的 API 格式";
+    }
+
+    return "";
   } catch {
-    return false;
+    return "URL格式错误";
   }
 };
 


### PR DESCRIPTION
修改Ollama默认base URL为172.17.0.1以适配Docker环境
重构isValidURL函数，增加对协议、本地地址和API格式的验证
移除ModelModal中冗余的验证逻辑和提示信息