### PR TITLE
ci(workflow): 更新 npm 发布工作流以支持 GitHub Packages 和 NPM 注册表

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   publish:
@@ -19,7 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@yokowu'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -40,8 +42,17 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           npm version $TAG_VERSION --no-git-tag-version
 
-      - name: Publish to NPM Registry
+      - name: Publish to GitHub Packages
         working-directory: ./ui/ModelModal
         run: pnpm publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to NPM Registry
+        working-directory: ./ui/ModelModal
+        run: |
+          npm config set registry https://registry.npmjs.org/
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          pnpm publish --no-git-checks
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
添加 packages:write 权限以支持 GitHub Packages 发布
将默认注册表更改为 GitHub Packages 并添加 scope 配置
同时保留向 NPM 注册表发布的功能