### PR TITLE
ci: 将npm发布从GitHub Packages迁移到NPM Registry

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
@@ -20,8 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@yokowu'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -42,17 +40,8 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           npm version $TAG_VERSION --no-git-tag-version
 
-      - name: Publish to GitHub Packages
+      - name: Publish to NPM Registry
         working-directory: ./ui/ModelModal
         run: pnpm publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to NPM Registry
-        working-directory: ./ui/ModelModal
-        run: |
-          npm config set registry https://registry.npmjs.org/
-          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-          pnpm publish --no-git-checks
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ui/ModelModal/package.json
+++ b/ui/ModelModal/package.json
@@ -16,7 +16,7 @@
     "./styles": "./dist/styles.css"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://registry.npmjs.org"
   },
   "files": [
     "dist"


### PR DESCRIPTION
更新package.json和CI配置，将包发布目标从GitHub Packages改为NPM Registry 移除不再需要的packages: write权限和冗余的npm配置步骤