### PR TITLE
fix(theme): 为lightTheme添加cssVarPrefix配置

### DIFF
--- a/ui/ModelModal/src/ModelModal.tsx
+++ b/ui/ModelModal/src/ModelModal.tsx
@@ -149,6 +149,9 @@ export const ModelModal: React.FC<ModelModalProps> = ({
         baseUrl = baseUrl.slice(0, -1)
         return true
       }
+      if (/\/v\d+$/.test(baseUrl)){
+        return true
+      }
       return baseUrl.endsWith('volces.com/api/v3')
     }
 

--- a/ui/ModelModal/src/theme.ts
+++ b/ui/ModelModal/src/theme.ts
@@ -10,7 +10,9 @@ const defaultTheme = createTheme();
 
 const lightTheme = createTheme(
   {
-    cssVariables: true,
+    cssVariables: {
+      cssVarPrefix: 'modelkit',
+    },
     palette: {
       // mode: 'light',
       primary: {


### PR DESCRIPTION
修复ModelModal中baseUrl验证逻辑，支持以/v数字结尾的URL