### PR TITLE
fix: 修正baseURL检查逻辑并处理以#结尾的URL

### DIFF
--- a/ui/ModelModal/src/ModelModal.tsx
+++ b/ui/ModelModal/src/ModelModal.tsx
@@ -586,6 +586,9 @@ export const ModelModal: React.FC<ModelModalProps> = ({
                   {/* 根据模型类型显示不同的URL后缀：embedding显示/embeddings，rerank显示/rerank，其他显示/chat/completions */}
                   {baseUrl && providers[providerBrand].urlWrite && (() => {
                     const processedUrl = getProcessedUrl(baseUrl, providerBrand);
+                    if (baseUrl.endsWith('#')) {
+                      return processedUrl;
+                    }
                     // 根据模型类型添加不同的后缀
                     if (model_type === 'embedding') {
                       return `${processedUrl}/embeddings`;

--- a/usecase/modelkit.go
+++ b/usecase/modelkit.go
@@ -534,7 +534,7 @@ func generateBaseURLFixSuggestion(errContent string, baseURL string, provider co
 	isOther = provider == consts.ModelProviderOther
 
 	var errType consts.AddModelBaseURLErrType
-	if strings.Contains(errContent, "chat/completions") {
+	if strings.Contains(baseURL, "chat/completions") {
 		errType = consts.AddModelBaseURLErrTypeChatCompletions
 	} else if isEndWithSlash {
 		errType = consts.AddModelBaseURLErrTypeSlash


### PR DESCRIPTION
修复generateBaseURLFixSuggestion中错误的errContent检查，改为检查baseURL 在ModelModal中添加对以#结尾的URL的特殊处理，避免重复添加后缀