### PR TITLE
refactor(handler): 重构ModelKit为ModelKitHandler并整合usecase依赖

### DIFF
--- a/test/backend/main.go
+++ b/test/backend/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"log/slog"
+	"net/http"
 	"os"
 
 	"github.com/labstack/echo/v4/middleware"
@@ -13,17 +13,20 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type ModelKit struct{
-	logger *slog.Logger
+type ModelKitHandler struct {
+	logger   *slog.Logger
+	modelkit *usecase.ModelKit
 }
 
 func NewModelKit(
 	echo *echo.Echo,
 	logger *slog.Logger,
 	isApmEnabled bool,
-) *ModelKit {
-	m := &ModelKit{
-		logger: logger,
+	modelkit *usecase.ModelKit,
+) *ModelKitHandler {
+	m := &ModelKitHandler{
+		logger:   logger,
+		modelkit: modelkit,
 	}
 
 	// 注册路由
@@ -34,7 +37,7 @@ func NewModelKit(
 	return m
 }
 
-func (p *ModelKit) GetModelList(c echo.Context) error {
+func (p *ModelKitHandler) GetModelList(c echo.Context) error {
 	var req domain.ModelListReq
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusOK, domain.Response{
@@ -44,8 +47,7 @@ func (p *ModelKit) GetModelList(c echo.Context) error {
 		})
 	}
 
-
-	resp, err := usecase.ModelList(c.Request().Context(), &req, p.logger)
+	resp, err := p.modelkit.ModelList(c.Request().Context(), &req)
 	if err != nil {
 		fmt.Println("err:", err)
 		return c.JSON(http.StatusOK, domain.Response{
@@ -62,7 +64,7 @@ func (p *ModelKit) GetModelList(c echo.Context) error {
 	})
 }
 
-func (p *ModelKit) CheckModel(c echo.Context) error {
+func (p *ModelKitHandler) CheckModel(c echo.Context) error {
 	var req domain.CheckModelReq
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, domain.Response{
@@ -71,7 +73,7 @@ func (p *ModelKit) CheckModel(c echo.Context) error {
 		})
 	}
 
-	resp, err := usecase.CheckModel(c.Request().Context(), &req, p.logger)
+	resp, err := p.modelkit.CheckModel(c.Request().Context(), &req)
 	if err != nil {
 		fmt.Println("err:", err)
 		return c.JSON(http.StatusOK, domain.Response{
@@ -115,7 +117,12 @@ func main() {
 	// 添加CORS中间件
 	echo.Use(middleware.CORS())
 
-	NewModelKit(echo, logger, false)
+	// 创建ModelKit
+	modelkit := usecase.NewModelKit(
+		logger,
+	)
+
+	NewModelKit(echo, logger, false, modelkit)
 
 	err := echo.Start(":8080")
 	if err != nil {


### PR DESCRIPTION
将ModelKit结构体重命名为ModelKitHandler，并添加modelkit作为依赖项。
将usecase中的ModelList和CheckModel方法重构为ModelKit结构体的成员方法。 优化日志记录方式，统一使用slog.Logger。